### PR TITLE
fix: address owner review findings across merged PRs #20/#22/#23

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,7 +529,7 @@ All configurable components use **frozen dataclasses** with sensible defaults:
 - `ImportError` with install instructions for optional deps (pyscf, cudaq, cupy, qiskit)
 - `RuntimeError` for failed SCF convergence, missing basis, etc.
 - `ValueError` for invalid configurations (validated in `__post_init__`)
-- `MemoryError` for matrices exceeding safe limits (>10K configs in `matrix_elements_fast`)
+- `MemoryError` for matrices exceeding safe limits (>50K configs in `matrix_elements_fast`); use `build_sparse_hamiltonian()` for larger bases
 
 ### Numba Strategy
 

--- a/README.md
+++ b/README.md
@@ -136,16 +136,39 @@ Each subpackage is self-contained with a clean public API. Lower-level modules h
 
 ## Available Molecules
 
+### Full-Space Systems
+
 | Name | Qubits | Basis Set |
 |------|--------|-----------|
 | H2   | 4      | sto-3g    |
-| LiH  | 12     | sto-6g    |
-| BeH2 | 14     | sto-6g    |
-| H2O  | 14     | sto-6g    |
-| NH3  | 16     | sto-6g    |
-| CH4  | 18     | sto-6g    |
+| LiH  | 12     | sto-3g    |
+| BeH2 | 14     | sto-3g    |
+| H2O  | 14     | sto-3g    |
+| NH3  | 16     | sto-3g    |
+| CH4  | 18     | sto-3g    |
 | N2   | 20     | cc-pvdz   |
+| CO   | 20     | sto-3g    |
+| HCN  | 22     | sto-3g    |
+| C2H2 | 24     | sto-3g    |
+| H2S  | 26     | sto-3g    |
 | C2H4 | 28     | sto-3g    |
+
+### CAS Active-Space Systems
+
+| Name | Qubits | Basis Set | Active Space |
+|------|--------|-----------|-------------|
+| N2-CAS(10,12)  | 24 | cc-pvdz | 10e, 12 orb |
+| Cr2             | 24 | sto-3g  | CAS(12,12)  |
+| N2-CAS(10,15)  | 30 | cc-pvdz | 10e, 15 orb |
+| Benzene         | 30 | sto-3g  | CAS(6,15)   |
+| N2-CAS(10,17)  | 34 | cc-pvdz | 10e, 17 orb |
+| Cr2-CAS(12,18) | 36 | cc-pvdz | 12e, 18 orb |
+| N2-CAS(10,20)  | 40 | cc-pvtz | 10e, 20 orb |
+| Cr2-CAS(12,20) | 40 | cc-pvdz | 12e, 20 orb |
+| N2-CAS(10,26)  | 52 | cc-pvtz | 10e, 26 orb |
+| Cr2-CAS(12,26) | 52 | cc-pvdz | 12e, 26 orb |
+| Cr2-CAS(12,28) | 56 | cc-pvdz | 12e, 28 orb |
+| Cr2-CAS(12,29) | 58 | cc-pvdz | 12e, 29 orb |
 
 ## Documentation
 

--- a/docs/decisions/004-cas-active-space-scale-up.md
+++ b/docs/decisions/004-cas-active-space-scale-up.md
@@ -123,7 +123,8 @@ failing test first → minimal implementation → refactor.
 - `create_cr2_hamiltonian(cas, basis, device)` — 24–58Q, with `fix_spin_`
 - `create_benzene_hamiltonian(basis, device)` — 30Q CAS(6,15)
 
-**Registry additions (12 new entries):**
+**Registry additions (12 new entries in BOTH `MOLECULE_REGISTRY` and
+`_MOLECULE_INFO_REGISTRY` — missing either triggers import-time `RuntimeError`):**
 - N₂-CAS(10,12/15/17/20/26): 24, 30, 34, 40, 52Q
 - Cr₂ + Cr₂-CAS(12,18/20/26/28/29): 24, 36, 40, 52, 56, 58Q
 - Benzene CAS(6,15): 30Q

--- a/src/qvartools/methods/nqs/hi_nqs_skqd.py
+++ b/src/qvartools/methods/nqs/hi_nqs_skqd.py
@@ -230,7 +230,9 @@ def run_hi_nqs_skqd(
     ------
     ValueError
         If ``mol_info`` is missing required keys, or if ``initial_basis``
-        has wrong shape, non-binary values, or floating-point dtype.
+        has wrong shape, non-binary values, or non-integer dtype.
+    RuntimeError
+        If all diagonalisation batches produce non-finite energies.
     """
     cfg = config or HINQSSKQDConfig()
 
@@ -277,7 +279,7 @@ def run_hi_nqs_skqd(
     # --- Cumulative basis (warm-start from initial_basis if provided) ---
     if initial_basis is not None:
         # Validate raw input before any cast (fail-fast)
-        if initial_basis.is_floating_point():
+        if initial_basis.is_floating_point() or initial_basis.is_complex():
             raise ValueError(
                 f"initial_basis must be integer dtype (binary occupations), "
                 f"got {initial_basis.dtype}"

--- a/src/qvartools/methods/nqs/hi_nqs_skqd.py
+++ b/src/qvartools/methods/nqs/hi_nqs_skqd.py
@@ -276,19 +276,20 @@ def run_hi_nqs_skqd(
 
     # --- Cumulative basis (warm-start from initial_basis if provided) ---
     if initial_basis is not None:
+        # Validate raw input before any cast (fail-fast)
         if initial_basis.is_floating_point():
             raise ValueError(
                 f"initial_basis must be integer dtype (binary occupations), "
                 f"got {initial_basis.dtype}"
             )
-        cumulative_basis = initial_basis.to(dtype=torch.long, device=device)
-        if cumulative_basis.ndim != 2 or cumulative_basis.shape[1] != n_qubits:
+        if initial_basis.ndim != 2 or initial_basis.shape[1] != n_qubits:
             raise ValueError(
                 f"initial_basis must have shape (n_configs, {n_qubits}), "
-                f"but got {tuple(cumulative_basis.shape)}"
+                f"but got {tuple(initial_basis.shape)}"
             )
-        if not torch.all((cumulative_basis == 0) | (cumulative_basis == 1)):
+        if not torch.all((initial_basis == 0) | (initial_basis == 1)):
             raise ValueError("initial_basis must contain only binary values {0, 1}")
+        cumulative_basis = initial_basis.to(dtype=torch.long, device=device)
         cumulative_basis = torch.unique(cumulative_basis, dim=0)
         logger.info(
             "Warm-starting with %d initial basis configs", cumulative_basis.shape[0]
@@ -393,11 +394,10 @@ def run_hi_nqs_skqd(
                 best_batch_configs = batch_configs
 
         if not batch_energies:
-            logger.warning(
-                "All batches produced non-finite energies at iteration %d",
-                iteration + 1,
+            raise RuntimeError(
+                f"All {cfg.n_batches} batches produced non-finite energies "
+                f"at iteration {iteration + 1}. Check Hamiltonian integrals."
             )
-            iter_energy = float("inf")
         else:
             iter_energy = float(np.min(batch_energies))
         energy_history.append(iter_energy)

--- a/src/qvartools/methods/nqs/hi_nqs_skqd.py
+++ b/src/qvartools/methods/nqs/hi_nqs_skqd.py
@@ -230,7 +230,7 @@ def run_hi_nqs_skqd(
     ------
     ValueError
         If ``mol_info`` is missing required keys, or if ``initial_basis``
-        has wrong shape, non-binary values, or non-integer dtype.
+        has wrong shape, non-binary values, or floating-point/complex dtype.
     RuntimeError
         If all diagonalisation batches produce non-finite energies.
     """
@@ -281,7 +281,7 @@ def run_hi_nqs_skqd(
         # Validate raw input before any cast (fail-fast)
         if initial_basis.is_floating_point() or initial_basis.is_complex():
             raise ValueError(
-                f"initial_basis must be integer dtype (binary occupations), "
+                f"initial_basis must be integer or bool dtype (binary occupations), "
                 f"got {initial_basis.dtype}"
             )
         if initial_basis.ndim != 2 or initial_basis.shape[1] != n_qubits:

--- a/src/qvartools/methods/nqs/hi_nqs_sqd.py
+++ b/src/qvartools/methods/nqs/hi_nqs_sqd.py
@@ -224,7 +224,9 @@ def run_hi_nqs_sqd(
     ------
     ValueError
         If ``mol_info`` is missing required keys, or if ``initial_basis``
-        has wrong shape, non-binary values, or floating-point dtype.
+        has wrong shape, non-binary values, or non-integer dtype.
+    RuntimeError
+        If all diagonalisation batches produce non-finite energies.
     """
     cfg = config or HINQSSQDConfig()
 
@@ -271,7 +273,7 @@ def run_hi_nqs_sqd(
     # --- Cumulative basis (warm-start from initial_basis if provided) ---
     if initial_basis is not None:
         # Validate raw input before any cast (fail-fast)
-        if initial_basis.is_floating_point():
+        if initial_basis.is_floating_point() or initial_basis.is_complex():
             raise ValueError(
                 f"initial_basis must be integer dtype (binary occupations), "
                 f"got {initial_basis.dtype}"

--- a/src/qvartools/methods/nqs/hi_nqs_sqd.py
+++ b/src/qvartools/methods/nqs/hi_nqs_sqd.py
@@ -224,7 +224,7 @@ def run_hi_nqs_sqd(
     ------
     ValueError
         If ``mol_info`` is missing required keys, or if ``initial_basis``
-        has wrong shape, non-binary values, or non-integer dtype.
+        has wrong shape, non-binary values, or floating-point/complex dtype.
     RuntimeError
         If all diagonalisation batches produce non-finite energies.
     """
@@ -275,7 +275,7 @@ def run_hi_nqs_sqd(
         # Validate raw input before any cast (fail-fast)
         if initial_basis.is_floating_point() or initial_basis.is_complex():
             raise ValueError(
-                f"initial_basis must be integer dtype (binary occupations), "
+                f"initial_basis must be integer or bool dtype (binary occupations), "
                 f"got {initial_basis.dtype}"
             )
         if initial_basis.ndim != 2 or initial_basis.shape[1] != n_qubits:

--- a/src/qvartools/methods/nqs/hi_nqs_sqd.py
+++ b/src/qvartools/methods/nqs/hi_nqs_sqd.py
@@ -270,19 +270,20 @@ def run_hi_nqs_sqd(
 
     # --- Cumulative basis (warm-start from initial_basis if provided) ---
     if initial_basis is not None:
+        # Validate raw input before any cast (fail-fast)
         if initial_basis.is_floating_point():
             raise ValueError(
                 f"initial_basis must be integer dtype (binary occupations), "
                 f"got {initial_basis.dtype}"
             )
-        cumulative_basis = initial_basis.to(dtype=torch.long, device=device)
-        if cumulative_basis.ndim != 2 or cumulative_basis.shape[1] != n_qubits:
+        if initial_basis.ndim != 2 or initial_basis.shape[1] != n_qubits:
             raise ValueError(
                 f"initial_basis must have shape (n_configs, {n_qubits}), "
-                f"but got {tuple(cumulative_basis.shape)}"
+                f"but got {tuple(initial_basis.shape)}"
             )
-        if not torch.all((cumulative_basis == 0) | (cumulative_basis == 1)):
+        if not torch.all((initial_basis == 0) | (initial_basis == 1)):
             raise ValueError("initial_basis must contain only binary values {0, 1}")
+        cumulative_basis = initial_basis.to(dtype=torch.long, device=device)
         cumulative_basis = torch.unique(cumulative_basis, dim=0)
         logger.info(
             "Warm-starting with %d initial basis configs", cumulative_basis.shape[0]
@@ -374,11 +375,10 @@ def run_hi_nqs_sqd(
                 best_batch_configs = batch_configs
 
         if not batch_energies:
-            logger.warning(
-                "All batches produced non-finite energies at iteration %d",
-                iteration + 1,
+            raise RuntimeError(
+                f"All {cfg.n_batches} batches produced non-finite energies "
+                f"at iteration {iteration + 1}. Check Hamiltonian integrals."
             )
-            iter_energy = float("inf")
         else:
             iter_energy = float(np.min(batch_energies))
         energy_history.append(iter_energy)

--- a/src/qvartools/molecules/registry.py
+++ b/src/qvartools/molecules/registry.py
@@ -529,6 +529,7 @@ def _make_cr2(
 
     if use_casci:
         mc = mcscf.CASCI(mf, ncas=ncas, nelecas=nelecas)
+        mc.fix_spin_(ss=0)  # Enforce singlet (needed for CASCI too)
     else:
         mc = mcscf.CASSCF(mf, ncas=ncas, nelecas=nelecas)
         mc.fix_spin_(ss=0)  # Enforce singlet

--- a/tests/test_hamiltonians/test_sparse_diag.py
+++ b/tests/test_hamiltonians/test_sparse_diag.py
@@ -19,6 +19,7 @@ import torch
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.pyscf
 class TestDenseLimitRaised:
     """Verify ``matrix_elements_fast`` now allows up to 50K configs."""
 

--- a/tests/test_hamiltonians/test_sparse_diag.py
+++ b/tests/test_hamiltonians/test_sparse_diag.py
@@ -47,6 +47,7 @@ class TestDenseLimitRaised:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.pyscf
 class TestBuildSparseHamiltonian:
     """Verify the new ``build_sparse_hamiltonian`` method."""
 
@@ -95,6 +96,7 @@ class TestBuildSparseHamiltonian:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.pyscf
 class TestSparseEigenvaluesMatchDense:
     """Compare eigenvalues from sparse and dense Hamiltonian construction."""
 
@@ -148,6 +150,7 @@ class TestSparseEigenvaluesMatchDense:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.pyscf
 class TestGpuSolveFermionSparseFallback:
     """Verify ``gpu_solve_fermion`` uses sparse path for large bases."""
 


### PR DESCRIPTION
## Summary

Fixes 7 issues from owner code reviews posted after PRs were merged.

| # | Source | Fix |
|---|--------|-----|
| 1 | PR #22 | Cr₂ CASCI path: add `fix_spin_(ss=0)` — was missing for ncas>=15, causing septet convergence |
| 2 | PR #22 | README.md: add 24 molecule table (12 full-space + 12 CAS) |
| 3 | PR #23 | AGENTS.md §5: correct `matrix_elements_fast` limit from 10K to 50K |
| 4 | PR #23 | test_sparse_diag.py: add `@pytest.mark.pyscf` to 3 test classes |
| 5 | PR #20 | Validation ordering: validate raw `initial_basis` BEFORE `.to()` cast |
| 6 | PR #20 | `float("inf")` → `RuntimeError` when all batches non-finite |
| 7 | PR #20 | ADR-004: note `_MOLECULE_INFO_REGISTRY` sync requirement |

**Not fixed (already resolved in main):**
- PR #24 ao2mo.restore: code already passes h2e directly (no reshape)
- PR #24 unconverged returns None: already returns None at line 293
- PR #24 test gap: n_orb=6 test at line 148 exercises CAS FCI kernel

## Test plan
- [x] 383 tests pass, ruff clean
- [x] Each fix verified against owner's exact line references