### PR TITLE
docs: add About page with authors and citation info

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,0 +1,61 @@
+About
+=====
+
+qvartools is developed and maintained by the
+`QuantumNoLab <https://github.com/QuantumNoLab>`_ team.
+
+Authors
+-------
+
+| **Jen-Yu Chang** — National Yang Ming Chiao Tung University
+| GitHub: `leo07010 <https://github.com/leo07010>`_ · ORCID: `0009-0009-7885-6857 <https://orcid.org/0009-0009-7885-6857>`_
+
+| **George Chang** — National Yang Ming Chiao Tung University
+| GitHub: `George930502 <https://github.com/George930502>`_
+
+| **Hsiu Chi Tsai** — National Yang Ming Chiao Tung University
+| GitHub: `thc1006 <https://github.com/thc1006>`_ · ORCID: `0000-0001-7421-8027 <https://orcid.org/0000-0001-7421-8027>`_
+
+| **monmon** — National Yang Ming Chiao Tung University
+| GitHub: `ericntunctu <https://github.com/ericntunctu>`_
+
+| **Ray Lin** — National Tsing Hua University
+| GitHub: `RayLin87564231 <https://github.com/RayLin87564231>`_
+
+| **yangsc11-beep** — National Yang Ming Chiao Tung University
+| GitHub: `yangsc11-beep <https://github.com/yangsc11-beep>`_
+
+How to Cite
+-----------
+
+If you use qvartools in your research, please cite:
+
+.. code-block:: bibtex
+
+   @software{qvartools2026,
+     author    = {Chang, Jen-Yu and Chang, George and Tsai, Hsiu Chi},
+     title     = {qvartools: Quantum Variational Toolkit},
+     year      = {2026},
+     url       = {https://github.com/QuantumNoLab/qvartools},
+     license   = {MIT},
+     version   = {0.0.0}
+   }
+
+A machine-readable citation file is available at
+`CITATION.cff <https://github.com/QuantumNoLab/qvartools/blob/main/CITATION.cff>`_.
+
+License
+-------
+
+qvartools is released under the
+`MIT License <https://github.com/QuantumNoLab/qvartools/blob/main/LICENSE>`_.
+
+Acknowledgements
+----------------
+
+qvartools builds on foundational work from the open-source quantum
+computing and quantum chemistry communities. Key dependencies include
+`PySCF <https://pyscf.org/>`_,
+`PyTorch <https://pytorch.org/>`_,
+`SciPy <https://scipy.org/>`_, and
+`NumPy <https://numpy.org/>`_.

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -16,14 +16,12 @@ Authors
 | **Hsiu Chi Tsai** — National Yang Ming Chiao Tung University
 | GitHub: `thc1006 <https://github.com/thc1006>`_ · ORCID: `0000-0001-7421-8027 <https://orcid.org/0000-0001-7421-8027>`_
 
-| **monmon** — National Yang Ming Chiao Tung University
-| GitHub: `ericntunctu <https://github.com/ericntunctu>`_
+Contributors
+------------
 
-| **Ray Lin** — National Tsing Hua University
-| GitHub: `RayLin87564231 <https://github.com/RayLin87564231>`_
-
-| **yangsc11-beep** — National Yang Ming Chiao Tung University
-| GitHub: `yangsc11-beep <https://github.com/yangsc11-beep>`_
+| **monmon** (`ericntunctu <https://github.com/ericntunctu>`_) — National Yang Ming Chiao Tung University
+| **Ray Lin** (`RayLin87564231 <https://github.com/RayLin87564231>`_) — National Tsing Hua University
+| **yangsc11-beep** (`yangsc11-beep <https://github.com/yangsc11-beep>`_) — National Yang Ming Chiao Tung University
 
 How to Cite
 -----------
@@ -41,7 +39,9 @@ If you use qvartools in your research, please cite:
      version   = {0.0.0}
    }
 
-A machine-readable citation file is available at
+The BibTeX entry lists the primary authors. For a complete list of
+contributors, see the Authors section above. A machine-readable
+citation file is available at
 `CITATION.cff <https://github.com/QuantumNoLab/qvartools/blob/main/CITATION.cff>`_.
 
 License

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -16,12 +16,14 @@ Authors
 | **Hsiu Chi Tsai** — National Yang Ming Chiao Tung University
 | GitHub: `thc1006 <https://github.com/thc1006>`_ · ORCID: `0000-0001-7421-8027 <https://orcid.org/0000-0001-7421-8027>`_
 
-Contributors
-------------
+| **monmon** — National Yang Ming Chiao Tung University
+| GitHub: `ericntunctu <https://github.com/ericntunctu>`_
 
-| **monmon** (`ericntunctu <https://github.com/ericntunctu>`_) — National Yang Ming Chiao Tung University
-| **Ray Lin** (`RayLin87564231 <https://github.com/RayLin87564231>`_) — National Tsing Hua University
-| **yangsc11-beep** (`yangsc11-beep <https://github.com/yangsc11-beep>`_) — National Yang Ming Chiao Tung University
+| **Ray Lin** — National Tsing Hua University
+| GitHub: `RayLin87564231 <https://github.com/RayLin87564231>`_
+
+| **yangsc11-beep** — National Yang Ming Chiao Tung University
+| GitHub: `yangsc11-beep <https://github.com/yangsc11-beep>`_
 
 How to Cite
 -----------
@@ -31,7 +33,8 @@ If you use qvartools in your research, please cite:
 .. code-block:: bibtex
 
    @software{qvartools2026,
-     author    = {Chang, Jen-Yu and Chang, George and Tsai, Hsiu Chi},
+     author    = {Chang, Jen-Yu and Chang, George and Tsai, Hsiu Chi
+                  and monmon and Lin, Ray and yangsc11-beep},
      title     = {qvartools: Quantum Variational Toolkit},
      year      = {2026},
      url       = {https://github.com/QuantumNoLab/qvartools},
@@ -39,9 +42,7 @@ If you use qvartools in your research, please cite:
      version   = {0.0.0}
    }
 
-The BibTeX entry lists the primary authors. For a complete list of
-contributors, see the Authors section above. A machine-readable
-citation file is available at
+A machine-readable citation file is available at
 `CITATION.cff <https://github.com/QuantumNoLab/qvartools/blob/main/CITATION.cff>`_.
 
 License

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,12 @@ Key capabilities:
 
    developer_guide/index
 
+.. toctree::
+   :maxdepth: 1
+   :caption: About
+
+   about
+
 Indices and tables
 ==================
 


### PR DESCRIPTION
## Summary

Adds an About page to ReadTheDocs documentation with team information and citation guidance.

**New files:**
- `docs/source/about.rst` — Authors (6 members, ORCID links), How to Cite (BibTeX), License, Acknowledgements

**Modified files:**
- `docs/source/index.rst` — "About" section added to sidebar toctree
- `CITATION.cff` — enriched with given-names, family-names, affiliation, ORCID per CFF spec

Page will appear at https://qvartools.readthedocs.io/en/latest/about.html after merge.