### PR TITLE
fix: cast initial_basis to long in 07_iterative_nqs_dci scripts (fixes #40)

### DIFF
--- a/experiments/pipelines/07_iterative_nqs_dci/iter_nqs_dci_krylov_classical.py
+++ b/experiments/pipelines/07_iterative_nqs_dci/iter_nqs_dci_krylov_classical.py
@@ -163,7 +163,11 @@ def main() -> None:
 
     history = pipeline.train_flow_nqs(progress=True)
     n_epochs = len(history.get("total_loss", []))
-    basis = pipeline.extract_and_select_basis()
+    # `extract_and_select_basis()` returns float32 (inherited from the
+    # NF trainer's accumulated_basis). `run_hi_nqs_skqd(initial_basis=...)`
+    # requires integer/bool dtype for the binary occupation vectors, so
+    # cast before passing.
+    basis = pipeline.extract_and_select_basis().long()
     nf_dci_energy = pipeline.results.get("final_energy")
 
     print(f"  NF training: {n_epochs} epochs")

--- a/experiments/pipelines/07_iterative_nqs_dci/iter_nqs_dci_sqd.py
+++ b/experiments/pipelines/07_iterative_nqs_dci/iter_nqs_dci_sqd.py
@@ -159,7 +159,11 @@ def main() -> None:
 
     history = pipeline.train_flow_nqs(progress=True)
     n_epochs = len(history.get("total_loss", []))
-    basis = pipeline.extract_and_select_basis()
+    # `extract_and_select_basis()` returns float32 (inherited from the
+    # NF trainer's accumulated_basis). `run_hi_nqs_sqd(initial_basis=...)`
+    # requires integer/bool dtype for the binary occupation vectors, so
+    # cast before passing.
+    basis = pipeline.extract_and_select_basis().long()
     nf_dci_energy = pipeline.results.get("final_energy")
     nf_time = time.perf_counter() - t_start
 


### PR DESCRIPTION
## Summary

Minimal surgical fix for #40: add `.long()` cast to the `basis` tensor before passing it as `initial_basis` in the two affected 07_iterative_nqs_dci scripts.

Closes #40.

## Affected files (2)

- `experiments/pipelines/07_iterative_nqs_dci/iter_nqs_dci_sqd.py`
- `experiments/pipelines/07_iterative_nqs_dci/iter_nqs_dci_krylov_classical.py`

## Diff summary

Each file gets one extra `.long()` call + a 4-line explanatory comment:

```diff
-    basis = pipeline.extract_and_select_basis()
+    # `extract_and_select_basis()` returns float32 (inherited from the
+    # NF trainer's accumulated_basis). `run_hi_nqs_sqd(initial_basis=...)`
+    # requires integer/bool dtype for the binary occupation vectors, so
+    # cast before passing.
+    basis = pipeline.extract_and_select_basis().long()
```

Total: **10 insertions, 2 deletions** across 2 files. No library changes, no API changes.

## Why this scope

See issue #40 for the full root-cause analysis. Short version: `extract_and_select_basis()` returns float32 (cloned from NF trainer's accumulated_basis), but the downstream `run_hi_nqs_sqd`/`run_hi_nqs_skqd` strictly validate integer/bool dtype. 008's sister scripts work because `expand_basis_via_connections()` happens to cast internally; 007 doesn't have that intermediate step.

Two cleaner long-term architectural fixes (cast at the library source, or relax the validator) are noted in the issue as out-of-scope. This PR is the minimum unblocking patch.

## Test plan

Manual end-to-end verification on H2/CPU:

- [x] Before fix: both scripts raise `ValueError: initial_basis must be integer or bool dtype ... got torch.float32`
- [x] After fix:
  - `iter_nqs_dci_sqd.py h2 --device cpu` → **Error 0.0 mHa**, 11.88 s
  - `iter_nqs_dci_krylov_classical.py h2 --device cpu` → **Error 0.0 mHa**, 9.32 s
- [x] `ruff check experiments/pipelines/07_iterative_nqs_dci/` — clean
- [x] `ruff format --check` — clean
- [ ] (Reviewer) Consider whether to also open a follow-up issue/PR for the root-cause library fix (cast in `extract_and_select_basis` or lenient validator)

## Relationship to PR #39

PR #39 (`refactor/pipeline-catalog`) renames `07_iterative_nqs_dci/` → `007_iterative_nqs_dci/` via `git mv`. This PR modifies file **content** (not paths) in `07_iterative_nqs_dci/`. The two PRs touch disjoint aspects of the same files, so git's rename detection should handle the rebase cleanly regardless of merge order.

Recommended merge order:
1. Merge this PR first (standalone, off main, no deps)
2. PR #39 rebases on main (picks up this fix at the old path, then renames folder)
3. OR merge PR #39 first — then this PR rebases (git detects rename, applies fix at the new path)

Either order works.